### PR TITLE
Update for SMAPI 2.0 and enable new SMAPI features

### DIFF
--- a/EmptyHands/EmptyHands.csproj
+++ b/EmptyHands/EmptyHands.csproj
@@ -11,8 +11,7 @@
     <AssemblyName>EmptyHands</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,14 +33,9 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -57,20 +51,11 @@
   </ItemGroup>
   <Import Project="..\..\PathoschildMods\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/EmptyHands/EmptyHands.csproj
+++ b/EmptyHands/EmptyHands.csproj
@@ -49,7 +49,6 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\..\PathoschildMods\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/EmptyHands/EmptyHandsMod.cs
+++ b/EmptyHands/EmptyHandsMod.cs
@@ -95,11 +95,16 @@ namespace EmptyHands
                 return;
 
             // perform bound action
-            this.Monitor.InterceptErrors("handling your input", $"handling input '{key}'", () =>
+            try
             {
                 if (key.Equals(map.SetToNothing))
                     this.UnsetActiveItem();
-            });
+            }
+            catch (Exception ex)
+            {
+                this.Monitor.Log($"Something went wrong handling input '{key}':\n{ex}", LogLevel.Error);
+                Game1.addHUDMessage(new HUDMessage("Huh. Something went wrong handling your input. The error log has the technical details.", HUDMessage.error_type));
+            }
         }
 
         /// <summary>Sets active item to an impossible value.</summary>

--- a/EmptyHands/EmptyHandsMod.cs
+++ b/EmptyHands/EmptyHandsMod.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
-using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.EmptyHands.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -30,15 +28,6 @@ namespace EmptyHands
             ControlEvents.KeyPressed += this.ControlEvents_KeyPressed;
             ControlEvents.ControllerButtonPressed += this.ControlEvents_ControllerButtonPressed;
             ControlEvents.ControllerTriggerPressed += this.ControlEvents_ControllerTriggerPressed;
-
-            // check for an updated version
-            if (this.Config.CheckForUpdates)
-            {
-                Task.Factory.StartNew(() =>
-                {
-                    UpdateHelper.LogVersionCheck(this.Monitor, this.ModManifest.Version, "EmptyHands").Wait();
-                });
-            }
         }
 
 

--- a/EmptyHands/Framework/ModConfig.cs
+++ b/EmptyHands/Framework/ModConfig.cs
@@ -13,8 +13,5 @@ namespace Pathoschild.Stardew.EmptyHands.Framework
 
         /// <summary>The controller input map.</summary>
         public InputMapConfiguration<Buttons> Controller { get; set; }
-
-        /// <summary>Whether to check for updates to the mod.</summary>
-        public bool CheckForUpdates { get; set; } = true;
     }
 }

--- a/EmptyHands/Framework/RawModConfig.cs
+++ b/EmptyHands/Framework/RawModConfig.cs
@@ -49,8 +49,7 @@ namespace Pathoschild.Stardew.EmptyHands.Framework
                 Controller = new InputMapConfiguration<Buttons>
                 {
                     SetToNothing = this.TryParse<Buttons>(monitor, this.Controller.SetToNothing)
-                },
-                CheckForUpdates = this.CheckForUpdates,
+                }
             };
         }
 

--- a/EmptyHands/Properties/AssemblyInfo.cs
+++ b/EmptyHands/Properties/AssemblyInfo.cs
@@ -1,36 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("EmptyHands")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Quicksilver Fox")]
-[assembly: AssemblyProduct("EmptyHands")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("c4bea490-0a36-4307-b5ff-da5cc007fcd1")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/EmptyHands/manifest.json
+++ b/EmptyHands/manifest.json
@@ -9,5 +9,6 @@
   },
   "Description": "Don't want to scare off people by swinging your scythe under their noses? Keep your hands empty!",
   "UniqueID": "QuicksilverFox.EmptyHands",
-  "EntryDll": "EmptyHands.dll"
+  "EntryDll": "EmptyHands.dll",
+  "UpdateKeys": [ "Nexus:1176" ]
 }

--- a/EmptyHands/manifest.json
+++ b/EmptyHands/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 0,
-    "PatchVersion": 0,
+    "PatchVersion": 1,
     "Build": null
   },
   "Description": "Don't want to scare off people by swinging your scythe under their noses? Keep your hands empty!",

--- a/EmptyHands/packages.config
+++ b/EmptyHands/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
 </packages>

--- a/NewGamePlus/ModConfig.cs
+++ b/NewGamePlus/ModConfig.cs
@@ -10,7 +10,6 @@ namespace NewGamePlus
     {
         public Dictionary<string, bool> config = new Dictionary<string, bool>()
         {
-            ["CheckForUpdates"] = true,
             ["professions"] = true,
             ["experience"] = false,
             ["stardrops"] = true,

--- a/NewGamePlus/NewGamePlus.cs
+++ b/NewGamePlus/NewGamePlus.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -8,7 +7,6 @@ using StardewValley.Menus;
 using StardewValley.Objects;
 using StardewValley.Locations;
 using NewGamePlus.Util;
-using Pathoschild.Stardew.Common;
 
 namespace NewGamePlus
 {
@@ -28,15 +26,6 @@ namespace NewGamePlus
             ModConfig = helper.ReadConfig<NewGamePlusConfig>();
 
             RegisterGameEvents();
-
-            // check for an updated version
-            if (ModConfig.GetConfig("CheckForUpdates"))
-            {
-                Task.Factory.StartNew(() =>
-                {
-                    UpdateHelper.LogVersionCheck(this.Monitor, this.ModManifest.Version, "NewGamePlus").Wait();
-                });
-            }
         }
 
         #region Events

--- a/NewGamePlus/NewGamePlus.csproj
+++ b/NewGamePlus/NewGamePlus.csproj
@@ -50,7 +50,6 @@
   <ItemGroup>
     <None Include="manifest.json" />
   </ItemGroup>
-  <Import Project="..\..\PathoschildMods\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/NewGamePlus/NewGamePlus.csproj
+++ b/NewGamePlus/NewGamePlus.csproj
@@ -11,8 +11,7 @@
     <AssemblyName>NewGamePlus</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,14 +33,9 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -51,9 +45,6 @@
     <Compile Include="Util\Professions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <WCFMetadata Include="Connected Services\" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -61,20 +52,11 @@
   </ItemGroup>
   <Import Project="..\..\PathoschildMods\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/NewGamePlus/Properties/AssemblyInfo.cs
+++ b/NewGamePlus/Properties/AssemblyInfo.cs
@@ -1,36 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("NewGamePlus")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Quicksilver Fox")]
-[assembly: AssemblyProduct("NewGamePlus")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0c0ed630-12e8-4830-ab02-ec72f4b9dac6")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NewGamePlus/manifest.json
+++ b/NewGamePlus/manifest.json
@@ -9,5 +9,6 @@
   },
   "Description": "Stuck in a groundhog day loop? You should at least learn from it.",
   "UniqueID": "QuicksilverFox.NewGamePlus",
-  "EntryDll": "NewGamePlus.dll"
+  "EntryDll": "NewGamePlus.dll",
+  "UpdateKeys": [ ]
 }

--- a/NewGamePlus/packages.config
+++ b/NewGamePlus/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
 </packages>

--- a/Quicksilver.Stardew.sln
+++ b/Quicksilver.Stardew.sln
@@ -1,20 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NewGamePlus", "NewGamePlus\NewGamePlus.csproj", "{0C0ED630-12E8-4830-AB02-EC72F4B9DAC6}"
-EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = ".Common", "..\PathoschildMods\Common\.Common.shproj", "{B9E9EDFC-E98A-4370-994F-40A9F39A0284}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmptyHands", "EmptyHands\EmptyHands.csproj", "{C4BEA490-0A36-4307-B5FF-DA5CC007FCD1}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\PathoschildMods\Common\Common.projitems*{0c0ed630-12e8-4830-ab02-ec72f4b9dac6}*SharedItemsImports = 4
-		..\PathoschildMods\Common\Common.projitems*{b9e9edfc-e98a-4370-994f-40a9f39a0284}*SharedItemsImports = 13
-		..\PathoschildMods\Common\Common.projitems*{c4bea490-0a36-4307-b5ff-da5cc007fcd1}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/latest-versions.json
+++ b/latest-versions.json
@@ -1,5 +1,5 @@
 {
   "schema": 1.0,
   "NewGamePlus": "1.0",
-  "EmptyHands": "1.0"
+  "EmptyHands": "1.0.1"
 }


### PR DESCRIPTION
This pull request...

* Updates the code for SMAPI 2.0.  
  <sup>(Technically [you did that](https://github.com/quicksilverfox/StardewMods/commit/af86ef7e8e3e77fcc3b12c340569455e8418ad26), but didn't release the update.)</sup>
* Updates the [mod build package](https://github.com/Pathoschild/Stardew.ModBuildConfig) to the latest version, and simplifies the build config using newer features.
* Removes the dependency on external code.
* Enables update checks in SMAPI 2.0+, and removes the manual update-check code.

If the changes look fine, can you release [EmptyHands 1.0.1.zip](https://github.com/quicksilverfox/StardewMods/files/1361562/EmptyHands.1.0.1.zip) to the [Nexus mod page](https://nexusmods.com/stardewvalley/mods/1176)?